### PR TITLE
Fix showing id to nearby players

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -33,7 +33,7 @@ AddEventHandler('qidentification:showID', function(item)
 		if #playersInArea > 0 then 
 			local Playerinareaid = {} -- Probably a better way of doing this, feel free to fix this :) -PERPGamer
 			for i = 1, #playersInArea do
-				table.insert(Playerinareaid, GetPlayerServerId(playersInArea[i]))
+				table.insert(Playerinareaid, GetPlayerServerId(NetworkGetPlayerIndexFromPed(playersInArea[i])))
 			end
 			TriggerServerEvent('qidentification:server:showID',item,Playerinareaid)
 			TriggerEvent('qidentification:openID',item)


### PR DESCRIPTION
For some reason, the ID is not showing to nearby players and an error popped up on the server-side:

[script:qidentificati] SCRIPT ERROR: Execution of native 000000002f7a49e6 in script host failed: Argument at index 1 was null.

Looks like the client-side didn't get the server ID correctly and passed an empty table to the server-side.